### PR TITLE
fix: Update app name to 'Repertoire Coach' across all platforms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
 
     <application
-        android:label="repertoire_coach"
+        android:label="Repertoire Coach"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="repertoire_coach">
+  <meta name="apple-mobile-web-app-title" content="Repertoire Coach">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>repertoire_coach</title>
+  <title>Repertoire Coach</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "repertoire_coach",
-    "short_name": "repertoire_coach",
+    "name": "Repertoire Coach",
+    "short_name": "Repertoire Coach",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
- Android: Updated android:label in AndroidManifest.xml
- Web: Updated title and meta tags in index.html
- Web: Updated name and short_name in manifest.json
- iOS: Already correctly configured as 'Repertoire Coach'

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)