### PR TITLE
fix: upgrade Android SDK from 35 to 36

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.repertoirecoach.repertoire_coach"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -31,7 +31,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        targetSdk = 35
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }


### PR DESCRIPTION
Updates compileSdk and targetSdk to version 36 to resolve build warning from flutter_plugin_android_lifecycle plugin.

Fixes #13

---
Generated with [Claude Code](https://claude.ai/code)